### PR TITLE
ci: create .env before prisma generate

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -55,14 +55,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Create .env file
+        run: echo "${{ secrets.ENV_FILE }}" > .env
+
       - name: Generate Prisma client
         run: pnpm db:generate
 
       - name: Build
         run: pnpm run build
-
-      - name: Create .env file
-        run: echo "${{ secrets.ENV_FILE }}" > .env
 
       - name: Setup SSH key
         run: |


### PR DESCRIPTION
## Summary
- Move .env file creation step before prisma generate to provide DATABASE_URL

## Test plan
- [ ] Verify prisma generate succeeds with DATABASE_URL available