### PR TITLE
ci: use bash script for deployment commands

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -88,19 +88,4 @@ jobs:
           key: ${{ secrets.SERVER_SSH_KEY }}
           script: |
             cd ~/storytime/development/storytime-waitlist
-
-            echo "📦 Installing dependencies..."
-            pnpm install --frozen-lockfile
-
-            echo "🗄 Running Prisma migrations..."
-            pnpm db:migrate
-
-            echo "Running Prisma generate..."
-            pnpm db:generate
-
-            echo "🚀 Restarting PM2 service..."
-            pm2 restart ecosystem.config.js || pm2 start ecosystem.config.js
-
-            pm2 save
-
-            echo "✅ Backend deployment completed successfully!"
+            bash scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+echo "📦 Installing dependencies..."
+pnpm install --frozen-lockfile
+
+echo "🗄 Running Prisma migrations..."
+pnpm db:migrate
+
+echo "Running Prisma generate..."
+pnpm db:generate
+
+echo "🚀 Restarting PM2 service..."
+pm2 restart ecosystem.config.js || pm2 start ecosystem.config.js
+
+pm2 save
+
+echo "✅ Backend deployment completed successfully!"


### PR DESCRIPTION
## Summary
- Move deployment commands from inline CI script to `scripts/deploy.sh`
- Avoids pnpm issues when running in CI environment

## Test plan
- [ ] Verify CI pipeline triggers on PR
- [ ] Verify deployment script runs successfully on server